### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Fazer checkout do repositório


### PR DESCRIPTION
Potential fix for [https://github.com/leoesilva/recicleaqui-20-back/security/code-scanning/3](https://github.com/leoesilva/recicleaqui-20-back/security/code-scanning/3)

To fix the problem, add a `permissions` key at the job level, above the steps but within the job definition (`build-and-test`). This restricts the effective permissions of the `GITHUB_TOKEN` for this job to read-only on repository contents, which is the minimally required privilege for typical CI tasks. No parts of the job as written appear to require any write privileges, as all steps (checkout, setup, install, lint, test) are read-only actions. The change is a one-line addition:

- In `.github/workflows/test.yml`, insert `permissions:\n  contents: read` between lines 10 and 11 (right after `runs-on: ubuntu-latest` and before `steps:`).

No additional imports or changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
